### PR TITLE
docs(guide):  updated readme guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,20 @@ The modules are:
 * Fetches configuration from backend & starts collection of measurements
 * Runtime API for applications to start and prolong measurements and metrics
 
+## Prerequisite
+
+Add the following to your environment's global `gradle.properties`
+
+```
+DEFAULT_CONFIG_URL_PREFIX="url to your configuration server"
+DEFAULT_LOCATION_URL_PREFIX="url to your location server"
+```
+
 ## How to build it
 
 ```bash
 $ git submodule init
 & git submodule update
-$ export DEFAULT_CONFIG_URL_PREFIX="url to your configuration server"
-$ export DEFAULT_LOCATION_URL_PREFIX="url to your location server"
 $ ./gradlew Runtime:assemble Plugin:assemble
 ```
 


### PR DESCRIPTION
Fix the Readme error:
Old Readme point to add `DEFAULT_CONFIG_URL_PREFIX` & `DEFAULT_LOCATION_URL_PREFIX`
  to system environment, but it should be added in to project’s global`gradle.properties`